### PR TITLE
handle None for redmine user first and last names

### DIFF
--- a/python/redmine2youtrack.py
+++ b/python/redmine2youtrack.py
@@ -211,7 +211,14 @@ class RedmineImporter(object):
             #user.login = redmine_user.login or 'guest'
             #user.email = redmine_user.mail or 'example@example.com'
             if user.login != 'guest':
-                user.fullName = redmine_user.firstname + ' ' + redmine_user.lastname
+                if redmine_user.firstname is None and redmine_user.lastname is None:
+                    user.fullName = user.login
+                elif redmine_user.firstname is None:
+                    user.fullName = redmine_user.lastname
+                elif redmine_user.lastname is None:
+                    user.fullName = redmine_user.firstname
+                else:
+                    user.fullName = redmine_user.firstname + ' ' + redmine_user.lastname
             else:
                 user.created = True
             if hasattr(redmine_user, 'groups'):


### PR DESCRIPTION
This fixes a situation we've had where the import fails because `firstname` (or `lastname`) of the redmine user comes back as `None`. In that case the string concatenation for the `user.fullName` raises a `TypeError` in python.
